### PR TITLE
Update gst.supp

### DIFF
--- a/gst.supp
+++ b/gst.supp
@@ -99,6 +99,14 @@
 }
 
 {
+   <g_type_init leaks>
+   Memcheck:Leak
+   fun:*alloc
+   ...
+   fun:g_option_context_parse
+}
+
+{
    <g_type_register_fundamental leaks>
    Memcheck:Leak
    fun:*alloc


### PR DESCRIPTION
This reduces the leaks detected by valgrind to 3,870 bytes in 75 blocks (test-program: gst_init(0, nullptr);  /  gst_deinit(); )